### PR TITLE
Fix typo & warnings, listen for IN_ATTRIB on Linux

### DIFF
--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -88,9 +88,9 @@ namespace filewatch {
 		FileWatch(T path, UnderpinningRegex pattern, std::function<void(const T& file, const Event event_type)> callback) :
 			_path(path),
 			_pattern(pattern),
-			_callback(callback),
-			_directory(get_directory(path))
+			_callback(callback)
 		{
+			_directory = get_directory(path);
 			init();
 		}
 
@@ -433,7 +433,7 @@ namespace filewatch {
 				}
 			}();
 
-			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE);
+			const auto watch = inotify_add_watch(folder, watch_path.c_str(), listen_filters);
 			if (watch < 0) 
 			{
 				throw std::system_error(errno, std::system_category());

--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -183,7 +183,7 @@ namespace filewatch {
 
 		FolderInfo  _directory;
 
-		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE;
+		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE | IN_ATTRIB;
 
 		const static std::size_t event_size = (sizeof(struct inotify_event));
 #endif // __unix__
@@ -471,6 +471,11 @@ namespace filewatch {
 								}
 								else if (event->mask & IN_MODIFY) 
 								{
+									parsed_information.emplace_back(T{ changed_file }, Event::modified);
+								}
+								else if (event->mask & IN_ATTRIB) 
+								{
+									// touch, for example, only generates ATTRIB, not MODIFY
 									parsed_information.emplace_back(T{ changed_file }, Event::modified);
 								}
 							}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ filewatch::FileWatch<std::wstring> watch(
 		case filewatch::Event::renamed_old:
 			std::cout << "The file was renamed and this is the old name." << '\n';
 			break;
-		case filewatch::ChangeType::renamed_new:
+		case filewatch::Event::renamed_new:
 			std::cout << "The file was renamed and this is the new name." << '\n';
 			break;
 		};


### PR DESCRIPTION
Without listening for IN_ATTRIB, touching a file goes unnoticed by filewatch (Linux). Fixed a few other problems.