### PR TITLE
Remove NOMINMAX macro redeclaration Windows warning

### DIFF
--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -25,7 +25,9 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
External libraries that make use of the `FileWatch.hpp` header file can have already defined the `NOMINMAX` macro. In this case Windows issues the following warning `'NOMINMAX': macro redefinition`. This PR only defines this macro if it has not been defined before.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>