### PR TITLE
Listen moved_to and moved_from events on Unix

### DIFF
--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -185,7 +185,7 @@ namespace filewatch {
 
 		FolderInfo  _directory;
 
-		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO;
+		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVE;
 
 		const static std::size_t event_size = (sizeof(struct inotify_event));
 #endif // __unix__
@@ -457,7 +457,7 @@ namespace filewatch {
 				}
 			}();
 
-			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVE);
 			if (watch < 0) 
 			{
 				throw std::system_error(errno, std::system_category());

--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -185,7 +185,7 @@ namespace filewatch {
 
 		FolderInfo  _directory;
 
-		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE;
+		const std::uint32_t _listen_filters = IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO;
 
 		const static std::size_t event_size = (sizeof(struct inotify_event));
 #endif // __unix__
@@ -457,7 +457,7 @@ namespace filewatch {
 				}
 			}();
 
-			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE);
+			const auto watch = inotify_add_watch(folder, watch_path.c_str(), IN_MODIFY | IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
 			if (watch < 0) 
 			{
 				throw std::system_error(errno, std::system_category());
@@ -497,6 +497,15 @@ namespace filewatch {
 								{
 									parsed_information.emplace_back(T{ changed_file }, Event::modified);
 								}
+                                else if (event->mask & IN_MOVED_FROM)
+                                {
+                                    parsed_information.emplace_back(T{ changed_file }, Event::renamed_old);
+                                }
+                                else if (event->mask & IN_MOVED_TO)
+                                {
+                                    parsed_information.emplace_back(T{ changed_file }, Event::renamed_new);
+                                }
+
 							}
 						}
 						i += event_size + event->len;


### PR DESCRIPTION
File renaming does not trigger events on Unix as it does on Windows. Defined necessary filters to support it to have the similar behavior in both platforms.