### PR TITLE
Fix crash when using std::wstring without UNICODE on Windows

### DIFF
--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -731,11 +731,11 @@ namespace filewatch {
 
                   DWORD length = IsWChar<C>::value? 
                         GetFullPathNameW((LPCWSTR)path.c_str(), 
-                              size / sizeof(TCHAR),
+                              size / sizeof(WCHAR),
                               (LPWSTR)buf,
                               nullptr) : 
                         GetFullPathNameA((LPCSTR)path.c_str(), 
-                              size / sizeof(TCHAR),
+                              size,
                               buf,
                               nullptr);
                   return StringType{(C*)buf, length};


### PR DESCRIPTION
While TCHAR is WCHAR in UNICODE mode, it doesn't have to be when using ANSI mode on Windows. Since we're hard-coding GetFullPathName*W*, we might as well hard-code the string type, as otherwise it will result in a hard to debug crash.