### PR TITLE
Improve cmake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.1)
 # Project name
 project( FileWatch VERSION 0.0.1 LANGUAGES C CXX)
 
+add_library(filewatch INTERACE)
+target_include_directories(filewatch INTERFACE {CMAKE_CURRENT_SOURCE_DIR})
+add_library(filewatch::filewatch ALIAS filewatch)
+
 option(BuildTests "Build the unit tests" ON)
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Single header folder/file watcher in C++11 for windows and linux, with optional 
 #### Install:
 Drop [FileWatch.hpp](https://github.com/ThomasMonkman/filewatch/blob/master/FileWatch.hpp) in to your include path, and you should be good to go.
 
+#### Install (through CMake):
+
+Use `filewatch` or `filewatch::filewatch` target in your project
+
+```cmake
+target_link_libraries(your_lib PRIVATE filewatch)
+# or
+target_link_libraries(your_lib PRIVATE filewatch::filewatch)
+# or
+link_libraries(filewatch)
+# or
+link_libraries(filewatch::filewatch)
+```
+
 #### Compiler Support:
 
 Works on:
@@ -15,6 +29,7 @@ Works on:
 - Clang 4 and higher    
 - GCC 4.8 and higher    
 - Visual Studio 2015 and higher should be supported, however only 2019 is on the ci and tested
+
 
 #### Examples:
 - [Simple](#1)


### PR DESCRIPTION
In case the user wants to have your lib as a submodule, they need to add the folder in the include directories directly
```cmake
target_include_directories(target PRIVATE path_to_filewatch)
```
which does work but looks a bit like a workaround.

Another approach commonly used (to my observation) is to create an imported target and use it
```cmake
add_library(filewatch INTERFACE IMPORTED)
target_include_directories(filewatch PUBLIC path_to_filewatch)
```
and use it as the import target.

The PR implements something like the last one, but instead directly in the library, giving the user the ability to simply do the following
```cmake
target_link_libraries(my_target PRIVATE filewatch::filewatch)
```