### PR TITLE
fix FileWatch delete constructor when building with gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.22.1)
 
 # Project name
 project( FileWatch VERSION 0.0.1 LANGUAGES C CXX)

--- a/FileWatch.hpp
+++ b/FileWatch.hpp
@@ -209,7 +209,7 @@ namespace filewatch {
 		}
 
 		// Const memeber varibles don't let me implent moves nicely, if moves are really wanted std::unique_ptr should be used and move that.
-		FileWatch<StringType>(FileWatch<StringType>&&) = delete;
+		FileWatch(FileWatch&&) = delete;
 		FileWatch<StringType>& operator=(FileWatch<StringType>&&) & = delete;
 
 	private:


### PR DESCRIPTION
Was running into a build error when compiling with gcc on Ubuntu 22.04. This commit fixes the error.